### PR TITLE
Created a channel list page.

### DIFF
--- a/channels.md
+++ b/channels.md
@@ -8,7 +8,7 @@ What do we talk about on this Slack instance? Here is a list of the channels on 
 
 * accessibility
   * Any and all questions regarding accessibility in UI development and design
-*admin
+* admin
   * Administrivia
 * beer
   * All about beer, like [this list of Irish Beers][irish-beers]

--- a/channels.md
+++ b/channels.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: Channel List
+permalink: /channels/
+---
+
+What do we talk about on this Slack instance? Here is a list of the channels on the 20th of January. Some are more active than others.
+
+* accessibility
+  * Any and all questions regarding accessibility in UI development and design
+*admin
+  * Administrivia
+* beer
+  * All about beer, like [this list of Irish Beers][irish-beers]
+* cluster_ie
+  * www.cluster.ie
+*design
+  * Web design, print design, app design, experience design, content design, design strategy, product design, design
+* development
+  * Conversations about development techniques and processes, Q and A, help and general techie-ness not limited to techies!
+* diversity
+  * We want this place to be interesting, fun and useful. People of different genders, different countries, colours, abilities as well as opinions are what we need to achieve this. Talk about how.
+* euvat
+  * Discussions about VATMOSS
+* events
+  * Event announcements
+* gaming
+  * What people are playing/want to play
+* general
+  * This is the general-purpose chat channel. Do explore others, don't feel you need to join them all though. 
+* ios
+  * All things Apple
+* js
+  * frameworks and load times and clients, oh my!
+* lambdas
+  * For functional programming enthusiasts, meetups etc.
+* llamas
+  * This channel is for llamas. Alpaca's are also acceptable.
+* movies
+  * The highway to the spoilerzone
+* otp
+  * All things OTP, Erlang, Elixir and all those tools.
+* podcast
+  * All about the [Verbose][verbose] podcast
+* random
+  * A place for non-work banter, links, articles of interest, humor or anything else which you'd like concentrated in some place other than work-related channels.
+* reading
+  * Not what you're reading *for*, just what you're reading *now*. And maybe next. Probably previously too.
+* ruby
+  * Rubyists report in
+* running
+  * Support for runners, fit and unfit, new and old.
+* shutupandtakemymoney
+  * A place to share some lovely products we all want to buy immediately.
+* sport
+  * Because it's better than coding.
+* standup
+  * Daily standup. Post what you got done yesterday and/or what you're gonna do today.
+* startupkids
+  * Families have people too.
+* wordpress
+  * Wordpress related recovery.
+
+[irish-beers]: http://www.belgiansmaak.com/irish-beers-to-try-in-2015/
+[verbose]: https://itunes.apple.com/ie/podcast/the-verbose-podcast/id652218985


### PR DESCRIPTION
Created a channel list page.
- initial list was manually created, using the https://api.slack.com/methods/channels.list/test method
- all archived channels were removed
- where appropriate, the channel purpose was displayed

Open question: should the number of channel members be displayed?
