### PR TITLE
Tweaks to channel list page

### DIFF
--- a/channels.md
+++ b/channels.md
@@ -14,7 +14,7 @@ What do we talk about on this Slack instance? Here is a list of the channels on 
   * All about beer, like [this list of Irish Beers][irish-beers]
 * cluster_ie
   * www.cluster.ie
-*design
+* design
   * Web design, print design, app design, experience design, content design, design strategy, product design, design
 * development
   * Conversations about development techniques and processes, Q and A, help and general techie-ness not limited to techies!

--- a/channels.md
+++ b/channels.md
@@ -13,7 +13,7 @@ What do we talk about on this Slack instance? Here is a list of the channels on 
 * beer
   * All about beer, like [this list of Irish Beers][irish-beers]
 * cluster_ie
-  * www.cluster.ie
+  * Coworking with [Cluster][cluster].
 * design
   * Web design, print design, app design, experience design, content design, design strategy, product design, design
 * development
@@ -63,3 +63,4 @@ What do we talk about on this Slack instance? Here is a list of the channels on 
 
 [irish-beers]: http://www.belgiansmaak.com/irish-beers-to-try-in-2015/
 [verbose]: https://itunes.apple.com/ie/podcast/the-verbose-podcast/id652218985
+[cluster]: http://www.cluster.ie


### PR DESCRIPTION
Fixed spacing around design entry.
Updated link to Cluster.

![itc-gh](https://cloud.githubusercontent.com/assets/1565392/5822385/866355fa-a0cb-11e4-850d-e28b27aa287a.PNG)
