### PR TITLE
Expose join link better

### DIFF
--- a/JoinITC.md
+++ b/JoinITC.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Join ITC
+permalink: /join-itc/
+---
+
+# Joining ITC
+We are always interested to meet new people.
+
+Come and join our community if you are:
+* interested in technology, or just want to talk to people or learn more about tech things,
+* have some connection to Ireland,
+* are a real person _(no bots, please)_, and
+* are willing to follow our [code of conduct](/codeofconduct).
+
+We have many [channels](/channels) devoted to a wide variety of subjects, from design and development of tech, to conferences, diversity, and more. Together, we are building a sustainable, diverse community of people who are interested in growing their skills, experience, community, and industry.
+
+# Sign up to the ITC Slack instance
+Please do not use company names, brand names or similar in your username. We do not have a 'real names' policy of any description, but expect members to communicate their personal opinions, rather than the opinions of brands, companies, or employers. Full details in the very short [code of conduct](/codeofconduct).
+<p class="button">
+      <a href="https://join.slack.com/t/irishtechcommunity/shared_invite/zt-1cuhuiqr9-2ED2NfEN0lrpYq26Sokp1w" target="_blank">
+        Sign up here
+      </a>
+</p>
+
+Welcome to ITC, the Irish Technology Community!

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
   <div class="wrapper">
 
    <!-- <a class="site-title" href="{{ site.baseurl }}/">{{ site.title }}</a> -->
-    <img src="https://raw.githubusercontent.com/IrishTechCommunity/irishtechcommunity.github.io/master/files/ITC-logos/itc-pride.png?raw=true"/>
+    <a class="site-title" href="{{ site.baseurl }}/"><img src="https://raw.githubusercontent.com/IrishTechCommunity/irishtechcommunity.github.io/master/files/ITC-logos/itc-pride.png?raw=true"/></a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">


### PR DESCRIPTION
- Makes the ITC icon clickable, linking back to the homepage
- Creates a new JoinITC page, with some simple details and the [Join] button on it (same as on the home page), making it easier for new users to find it.

Why: because search engines often 'deep link' into one of the sub pages of the website, and until this PR, I could not find a way for a user to find the home page and the [Join] link without manually editing the URL.

Resolves #58 