### PR TITLE
Removed links and mentions of twitter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,6 @@ email: info@irishtechcommunity.com
 description: A slack channel for people interested in, or working in the Irish tech industry
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://irishtechcommunity.com" # the base hostname & protocol for your site
-twitter_username: irishtechslack
 
 # Build settings
 markdown: kramdown

--- a/channels.md
+++ b/channels.md
@@ -6,177 +6,175 @@ permalink: /channels/
 
 What do we talk about on this Slack instance? Here is a list of the channels on the 19th of February. Some are more active than others.
 
-* general 
+* general
    * Banter!
-* random 
+* random
    * A place for non-work banter, links, articles of interest, humor or anything else which you'd like concentrated in some place other than work-related channels.
-* events 
+* events
    * <a href="http://irishtechcommunity.com/meetupvenues/">irishtechcommunity.com/meetupvenues/</a>
-* design 
+* design
    * Web design, print design, app design, experience design, content design, design strategy, product design, design
-* js 
+* js
    * JavaScript, frameworks, etc.
-* conferences 
+* conferences
    * conferences in Ireland discussion
-* ruby 
+* ruby
    * Rubyists report in
-* python 
+* python
    * import this
-* lambdas 
+* lambdas
    * For functional programming enthusiasts, meetups etc.
-* hackathon 
+* hackathon
    * Discuss past and upcoming hackathons. Future and past attendees welcome.
-* coffee 
+* coffee
    * Talking about coffee
-* linux 
+* linux
    * For discussions about Microsoft Windows
-* students 
+* students
    * Irish Tech Student Community
-* angularjs 
+* angularjs
    * The purpose is talk about angularjs, best practice, discuss specific topics and introduce new people in angularjs world
-* twitter 
-   * Tweets to and from the @irishtechslack account
-* jobs 
+* jobs
    * Are you hiring? Need a job? This is the channel for you.
-* development 
+* development
    * Conversations about development techniques and processes, Q and A, help and general techie-ness not limited to techies!
-* shutupandtakemymoney 
+* shutupandtakemymoney
    * A place to share some lovely products we all want to buy immediately.
-* ios 
+* ios
    * All things Apple
-* business 
+* business
    * Anything todo with the business of tech...
-* diversity 
+* diversity
    * We want this place to be interesting, fun and useful. People of different genders, different countries, colours, abilities as well as opinions are what we need to achieve this. Talk about how.
-* reading 
+* reading
    * _No description._
-* beer 
+* beer
    * beer
-* androiddev 
+* androiddev
    * Building little green robots.
-* bootstrapping 
+* bootstrapping
    * Support group for Bootstrappers, eg. https://gettingreal.37signals.com and https://unicornfree.com/
-* gaming 
+* gaming
    * _No description._
-* startupkids 
+* startupkids
    * Maybe this won't work but this is for startup people with kids...
-* remote 
+* remote
    * Remote working, working from home, coffee shops etc.
-* marriage_equality 
+* marriage_equality
    * Helping the Irish tech community collaborate on ways to help the Marriage Equality campaign
-* apple 
+* apple
    * All things fruity but particularly for those annual launch events
-* movies 
+* movies
    * The highway to the spoilerzone
-* pitches 
+* pitches
    * Ask for feed back on your deck, how to pitch, how not to pitch, how to get in front of the right people.
-* food 
+* food
    * om nom nom
-* podcast 
+* podcast
    * Live stream of the verbose podcast - throw in links and ideas for us to talk about
-* php 
+* php
    * PHP is cool again.
-* tunes 
+* tunes
    * Share what you're listening to right now.
-* running 
+* running
    * Support for runners, fit and unfit, new and old.
-* bitcoin 
+* bitcoin
    * _No description._
-* gifs 
+* gifs
    * no talking, just gifs. if you get caught talking, that is a penalty of three unique gifs you must supply to the channel in order to receive absolution. NO TALKING JUST GIFS
-* writing 
+* writing
    * There is nothing to writing. All you do is sit down at a typewriter and bleed.
-* game_development 
+* game_development
    * _No description._
-* wordpress 
+* wordpress
    * Erra shure feck it.
-* sport 
+* sport
    * Because it's better than coding.
-* admin 
+* admin
    * Administrivia
-* mornin 
+* mornin
    * A channel to say good morning in. The only acceptable words are as follows: "good morning", "morning", "mornin'", "moin", "m". The use of graphics to communicate the intent of "Good Morning" is also permitted.
-* otp 
+* otp
    * All things OTP, Erlang, Elixir and all those tools.
-* golang 
+* golang
    * Come for the Go, stay for the convenient binaries and concurrency
-* html5 
+* html5
    * For discussing HTML5-specific topics.
-* photography 
+* photography
    * To discuss photography, practice, techniques, gear, services, etc.
-* operations 
+* operations
    * Linux/Networking/Deployment/Docker Docker Docker
-* ml 
+* ml
    * Machine Learning, NLP and understanding of  unstructured data.
-* rant 
+* rant
    * For when you have to explain at length that the person who held you up at the train stop for eleven seconds this morning is a GODDAMN GOAT-BOTHERING OXYGEN-STEALING PAIN IN THE FUNDAMENT WHO HAS DIRECTLY CAUSED ALL THE PROBLEMS IN THE UNIVERSE EVER.
-* sbc 
+* sbc
    * Single Board Computers - Chat about Raspberry Pi, Arduino, and related tech
-* java 
+* java
    * _No description._
-* edtech 
+* edtech
    * Chat about education and learning technology, knowledge economy, lifelong learning and technology trends
-* newrelic 
+* newrelic
    * New Relic performance monitoring stuff. Not affiliated with New Relic per se. Results may vary. For legit help, go to support.newrelic.com
-* politics 
-   * How things work, politically and what not. 
-* datascience 
+* politics
+   * How things work, politically and what not.
+* datascience
    * Irish Data Scientists Community
-* fiction 
+* fiction
    * What fiction books are you reading?
-* growth 
+* growth
    * Share growth tips. What is growth? User acquisition, on-page optimization, A/B testing, email marketing, referral campaigns, retention.
-* tv 
+* tv
    * Spoilers are Coming
-* alcohol 
+* alcohol
    * For discussion of all things alcoholic. Except beer. Those snobs have their own channel.
-* galway 
+* galway
    * Channel for the Tech community focused in the Galway area.
-* sfbay 
+* sfbay
    * For the Irish visiting/living in the SF Bay Area
-* music 
+* music
    * What are you listening to?
-* starwars 
+* starwars
    * all things Star Wars!
-* elasticsearch 
+* elasticsearch
    * All things Elasticsearch and the ELK stack, Lucene and beyond.
-* llamas 
+* llamas
    * This channel is for llamas. Alpaca's are also acceptable.
-* cluster_ie 
+* cluster_ie
    * www.cluster.ie
-* design-share 
+* design-share
    * A place to share design projects you’re working on
-* future 
+* future
    * Brainstorm on products and services we want to have, ways to live, learn and work. Connect with people experimenting with ideas, businesses and innovation strategies.
-* virtual_reality 
+* virtual_reality
    * Chat about virtual and augmented reality development, applications, business.
-* testing 
+* testing
    * Let’s break shit.
-* crypto 
+* crypto
    * Talking about cryptography, it's use day-to-day and in our apps. Shout your ideas in here for review by others.
-* hardware 
+* hardware
    * Hardware Tech
-* starwars_spoilers 
+* starwars_spoilers
    * You’ve seen it and you want to shoot first in a wretched hive of scum and villainy. HERE BE SPOILERS.
-* fitness 
+* fitness
    * _No description._
-* getwave 
+* getwave
    * Looking for betatesters for a new bank in the UK and Ireland
-* euvat 
+* euvat
    * ewwww
-* civictech 
+* civictech
    * _No description._
-* travel 
+* travel
    * Sometimes we have to go far away to do a job that can be done remotely. Go figure.
-* malewellness 
+* malewellness
    * Shaving
-* ggd-computing-museum 
+* ggd-computing-museum
    * Discuss the computing museum formation
-* ansible 
+* ansible
    * Ansible all the things
-* ddd 
+* ddd
    * Discuss Domain Driven Design
-* jokes 
+* jokes
    * Funny &amp; clever jokes. No punching-down jokes. Don't make me regret creating this.
-* blab 
+* blab
    * _No description._


### PR DESCRIPTION
Removes twitter from config for social media items.
Removes the mention of the twitter channel from the channels list, which seems to have made the diff all weird. 